### PR TITLE
Filter out contract addresses

### DIFF
--- a/src/eth/rpc.ts
+++ b/src/eth/rpc.ts
@@ -40,9 +40,13 @@ const isEOA = async (address: string) => {
     return provider.getCode(address) === "0x"
 }
 
+const isOrchestrator = async (item) => {
+    return item.id === item.delegate.id;
+}
+
 const filterAddresses = async (arr) => {
     const results = await Promise.all(
-        arr.map(item => isEOA(item.id))
+        arr.map(item => (isEOA(item.id) || !isOrchestrator(item)))
     );
     return arr.filter((_v, index) => results[index]);
 }

--- a/src/eth/rpc.ts
+++ b/src/eth/rpc.ts
@@ -37,16 +37,20 @@ const getDelegatorSnapshot = async (
   };
 };
 const isEOA = async (address: string) => {
-    return provider.getCode(address) === "0x"
+    return (await provider.getCode(address)) === "0x"
 }
 
-const isOrchestrator = async (item) => {
+const isOrchestrator = (item) => {
     return item.id === item.delegate.id;
 }
 
 const filterAddresses = async (arr) => {
+    // remove orchestrators
+    const noOrchs = arr.filter(item => !isOrchestrator(item))
+
+    // remove contract accounts
     const results = await Promise.all(
-        arr.map(item => (isEOA(item.id) || !isOrchestrator(item)))
+        noOrchs.map(item => isEOA(item.id))
     );
     return arr.filter((_v, index) => results[index]);
 }


### PR DESCRIPTION
- added filter to remove contract addresses immediately after fetching from subgraph
- pendingStake and pendingFees will be fetched parallely to reduce execution time

will increase execution time as a fetch call has to be made for each address

closes #5 