### PR TITLE
Use solidityPack instead of AbiCoder.encode for leaves

### DIFF
--- a/src/cmd/index.ts
+++ b/src/cmd/index.ts
@@ -174,7 +174,7 @@ export async function verify(address:string) {
         console.log("\n")
 
         // get leaf
-        const leaf = utils.defaultAbiCoder.encode(["address", "address", "uint256", "uint256"], [snapshotEarnings?.delegator, snapshotEarnings?.delegate, snapshotEarnings?.pendingStake, snapshotEarnings?.pendingFees])
+        const leaf = utils.solidityPack(["address", "address", "uint256", "uint256"], [snapshotEarnings?.delegator, snapshotEarnings?.delegate, snapshotEarnings?.pendingStake, snapshotEarnings?.pendingFees])
 
         // get proof
         const proof = await oraPromise(generateProof(tree, leaf), {text: "Generating merkle proof", indent: 2})
@@ -211,7 +211,7 @@ export async function claim(keystoreFile) {
     const snapshotEarnings = await earnings(wallet.address)
 
     // get leaf
-    const leaf = utils.defaultAbiCoder.encode(["address", "uint256", "uint256"], [snapshotEarnings?.delegator, snapshotEarnings?.pendingStake, snapshotEarnings?.pendingFees])
+    const leaf = utils.solidityPack(["address", "uint256", "uint256"], [snapshotEarnings?.delegator, snapshotEarnings?.pendingStake, snapshotEarnings?.pendingFees])
 
     // reconstruct tree 
     let LIP = promptUserInput();

--- a/src/cmd/index.ts
+++ b/src/cmd/index.ts
@@ -81,15 +81,11 @@ export async function earnings(address:string) {
 
 export async function generate() {
     try {
-        const round = await getSnapshotRound()
         let delegators = await oraPromise(getDelegators(), {text: "Fetching all delegators, this might take a while...", indent: 2})
         if (!delegators) return;
         delegators = delegators.filter(d => d.delegator != "0x0000000000000000000000000000000000000000" || d.delegator)
         // generate merkle tree
         const treeSpinner = ora({text: "Generating Merkle Tree", indent: 2}).start()
-        // const leaves = delegators.map(d => utils.defaultAbiCoder.encode(["address", "uint256", "uint256"], [d.delegator, d.pendingStake, d.pendingFees]))
-        // console.log(leaves)
-        // const tree = new MerkleTree(leaves)
         const tree = new EarningsTree(delegators)
         if (!tree) {
             treeSpinner.fail()

--- a/src/tree/index.ts
+++ b/src/tree/index.ts
@@ -142,7 +142,7 @@ export interface EarningsTree extends MerkleTree {
 
 export class EarningsTree extends MerkleTree {
   constructor(delegators) {
-    let leaves = delegators.map(d => utils.defaultAbiCoder.encode(["address", "address", "uint256", "uint256"], [d.delegator, d.delegate, d.pendingStake, d.pendingFees]))
+    let leaves = delegators.map(d => utils.solidityPack(["address", "address", "uint256", "uint256"], [d.delegator, d.delegate, d.pendingStake, d.pendingFees]))
     super(leaves)
     this.leaves = leaves
   }


### PR DESCRIPTION
The L2Migrator uses [abi.encodePacked](https://github.com/livepeer/arbitrum-lpt-bridge/blob/f3bce92768831fe4bf60b944c67ad65905159c79/contracts/L2/gateway/L2Migrator.sol#L264) to encode the elements of a leaf instead of `abi.encode`. These two encoding functions produce different results because the former tightly packs values and the latter does not. `solidityPack` from `ethers` replicates the behavior of `abi.encodePacked` so we can replace calls to `AbiCoder.encode` with calls to `solidityPack`.

This PR also remove some stale code in 05048694dc841fc50b4110fb97a07dc0a9774954.